### PR TITLE
Update dependencies for halogen, halogen-css, and formatters

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,10 +21,10 @@
   ],
   "dependencies": {
     "purescript-enums": "^3.2.0",
-    "purescript-formatters": "^2.0.0",
+    "purescript-formatters": "^3.0.0",
     "purescript-datetime": "^3.3.0",
-    "purescript-halogen": "^2.0.1",
-    "purescript-halogen-css": "^6.0.0",
+    "purescript-halogen": "^3.0.1",
+    "purescript-halogen-css": "^7.0.0",
     "purescript-generics-rep": "^5.0.0",
     "purescript-validation": "^3.1.0",
     "purescript-profunctor": "^3.1.0",


### PR DESCRIPTION
Several libraries this package depends on have had major version bumps that make this incompatible with new projects. I've updated those packages and confirmed that this still builds properly after doing so. Updating this package to use the new versions is necessary to upgrade other packages like [purescript-markdown-halogen](https://github.com/slamdata/purescript-markdown-halogen).

```sh
 purescript-formatters   ^2.0.0  →  ^3.0.0
 purescript-halogen      ^2.0.1  →  ^3.0.1
 purescript-halogen-css  ^6.0.0  →  ^7.0.0
```